### PR TITLE
Actual vapor pressure estimation when RH is not present in data

### DIFF
--- a/pyet/meteo_utils.py
+++ b/pyet/meteo_utils.py
@@ -264,7 +264,11 @@ def calc_ea(tmean=None, tmax=None, tmin=None, rhmax=None, rhmin=None, rh=None, e
             es = calc_es(tmax=tmax, tmin=tmin)
         else:
             es = calc_e0(tmean)
-        return rh / 100 * es
+        if rh is None and tmin is not None:
+            ea = calc_e0(tmin) # assuming Tdew close to Tmin, Allen 1998
+        else:
+            ea = rh / 100 * es 
+        return ea
 
 
 def day_of_year(tindex):

--- a/pyet/meteo_utils.py
+++ b/pyet/meteo_utils.py
@@ -1,6 +1,4 @@
-"""The meteo_utils module contains utility functions for meteorological data.
-
-"""
+"""The meteo_utils module contains utility functions for meteorological data."""
 
 from numpy import cos, exp, isnan, log, pi, sin, tan
 from pandas import Series, to_numeric
@@ -265,9 +263,9 @@ def calc_ea(tmean=None, tmax=None, tmin=None, rhmax=None, rhmin=None, rh=None, e
         else:
             es = calc_e0(tmean)
         if rh is None and tmin is not None:
-            ea = calc_e0(tmin) # assuming Tdew close to Tmin, Allen 1998
+            ea = calc_e0(tmin)  # assuming Tdew close to Tmin, Allen 1998
         else:
-            ea = rh / 100 * es 
+            ea = rh / 100 * es
         return ea
 
 


### PR DESCRIPTION
# Short Description
Added an Actual vapor pressure estimation when RH is not provided following Allen et al. (1998) recommendation. This assumes that dew temperature is close to the minimum temperature.

Without this change, Priestley-Taylor method fails even when RH is listed as an optional parameter. Minimum reproducible example:

```
import pandas as pd
import pyet
import matplotlib.pyplot as plt

data_16412 = pd.read_csv('data/example_1/klima_daily.csv', index_col=1, parse_dates=True)
data_16412

meteo = pd.DataFrame({"time":data_16412.index, "tmean":data_16412.t, "tmax":data_16412.tmax, "tmin":data_16412.tmin, "rh":data_16412.rel, 
                      "wind":data_16412.vv, "rs":data_16412.strahl/100})
time, tmean, tmax, tmin, rh, wind, rs = [meteo[col] for col in meteo.columns]

lat = 47.077778*np.pi/180  
elevation = 367  

pet1 = pyet.priestley_taylor(tmean, tmax=tmax, tmin=tmin, rs=rs, elevation=elevation, lat=lat, rh=rh)
pet2 = pyet.priestley_taylor(tmean, tmax=tmax, tmin=tmin, rs=rs, elevation=elevation, lat=lat)

plt.scatter(pet1, pet2)
```

# Checklist before PR can be merged:
- [ ] closes issue #xxxx
- [X] is documented
- [X] Format code with [Black formatting](https://black.readthedocs.io)
- [ ] type hints for functions and methods
- [ ] tests added / passed
- [ ] Example Notebook (for new features)
- [ ] Remove output for all notebooks with changes
